### PR TITLE
Fix top level navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
 gem 'turbolinks'
+gem 'jquery-turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem "attr_encrypted", "~> 3.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,9 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.3)
     jwt (1.5.4)
     launchy (2.4.3)
@@ -215,6 +218,7 @@ DEPENDENCIES
   figaro
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-turbolinks
   launchy
   mocha
   omniauth-google-oauth2

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery.turbolinks
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .


### PR DESCRIPTION
The issue with this was that Turbolinks broke the listener/handler that
materialize setups. By installing the jQuery turbolinks package, the
handler is attached correctly and the top nav now works.
